### PR TITLE
BUG: Declare visualization_type on RoughnessParameters workflow

### DIFF
--- a/topobank_statistics/workflows.py
+++ b/topobank_statistics/workflows.py
@@ -824,6 +824,7 @@ class RoughnessParameters(WorkflowImplementation):
     class Meta:
         name = "topobank_statistics.roughness_parameters"
         display_name = "Roughness parameters"
+        visualization_type = VIZ_ROUGHNESS_PARAMETERS
 
         implementations = {
             Topography: "topography_implementation",


### PR DESCRIPTION
The RoughnessParameters workflow renders with the dedicated RoughnessParametersCard, but did not declare `visualization_type`, so (once the API serializes the field) the analysis page would fall back to the default series card. Set `Meta.visualization_type = VIZ_ROUGHNESS_PARAMETERS`.

Companion to ContactEngineering/topobank-rest-api (which serializes `visualization_type`, defaulting to `series`) — together they fix the blank analysis cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)