### PR TITLE
BUG: Fix y-direction scale-dependent roughness and slope histogram masking

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -448,9 +448,27 @@ def test_scale_dependent_slope_simple_2d_topography(simple_linear_2d_topography)
     assert sorted(result.keys()) == EXPECTED_KEYS_FOR_PLOT_CARD_ANALYSIS
 
     assert result["name"] == "Scale-dependent slope"
-    for dataset in result["series"]:
-        if dataset["name"] == "Along y":
-            np.testing.assert_almost_equal(dataset["y"], 2 * np.ones_like(dataset["y"]))
+
+    # ScaleDependentSlope emits series named "Slope in x-direction",
+    # "Slope in y-direction" and "Gradient" (see the xname/yname arguments in
+    # ScaleDependentSlope.topography_implementation). For h(x,y) = -2y + 9 the
+    # slope in y-direction has magnitude 2 everywhere and the slope in
+    # x-direction is 0 everywhere.
+    series_by_name = {dataset["name"]: dataset for dataset in result["series"]}
+
+    # Only reliable scales carry finite values; unreliable scales are NaN. We
+    # assert on the finite entries (there must be at least one).
+    assert "Slope in y-direction" in series_by_name
+    slope_y = np.asarray(series_by_name["Slope in y-direction"]["y"])
+    finite_y = slope_y[np.isfinite(slope_y)]
+    assert len(finite_y) > 0
+    np.testing.assert_almost_equal(finite_y, 2 * np.ones_like(finite_y))
+
+    assert "Slope in x-direction" in series_by_name
+    slope_x = np.asarray(series_by_name["Slope in x-direction"]["y"])
+    finite_x = slope_x[np.isfinite(slope_x)]
+    assert len(finite_x) > 0
+    np.testing.assert_almost_equal(finite_x, np.zeros_like(finite_x))
 
 
 def test_variable_bandwidth_simple_2d_topography(simple_linear_2d_topography):

--- a/topobank_statistics/workflows.py
+++ b/topobank_statistics/workflows.py
@@ -67,6 +67,8 @@ class HeightDistribution(WorkflowImplementation):
         minval = mean_height - wfac * rms_height
         maxval = mean_height + wfac * rms_height
         x_gauss = np.linspace(minval, maxval, 1001)
+        # TODO: divide-by-zero when rms_height == 0 (flat topography) produces
+        # inf/nan in the Gaussian fit; guard rms_height before dividing.
         y_gauss = np.exp(-((x_gauss - mean_height) ** 2) / (2 * rms_height**2)) / (
             np.sqrt(2 * np.pi) * rms_height
         )
@@ -151,7 +153,11 @@ def _moments_histogram_gaussian(
     result['series'].extend(series)
     """
 
-    arr = arr.flatten()
+    # Compress the (possibly) masked array to drop masked entries before
+    # histogramming. np.histogram would otherwise strip the mask via
+    # np.asarray and bin the fill values. This also keeps mean/rms consistent
+    # with the histogrammed data. For non-masked inputs this simply flattens.
+    arr = np.ma.compressed(arr)
 
     mean = arr.mean()
     rms = np.sqrt((arr**2).mean())
@@ -168,6 +174,9 @@ def _moments_histogram_gaussian(
             (exc.args[0] == "supplied range of [0.0, inf] is not finite")
             or ("is reentrant" in exc.args[0])
         ):
+            # TODO: this message hard-codes "curvature distribution", but this
+            # helper is also used for the slope distribution; make the message
+            # reflect the actual quantity being computed.
             raise ReentrantDataError(
                 "Cannot calculate curvature distribution for reentrant measurements."
             )
@@ -190,6 +199,8 @@ def _moments_histogram_gaussian(
         minval = mean - wfac * rms
         maxval = mean + wfac * rms
         x_gauss = np.linspace(minval, maxval, 1001)
+        # TODO: divide-by-zero when rms == 0 produces inf/nan in the Gaussian
+        # fit; guard rms before dividing.
         y_gauss = np.exp(-((x_gauss - mean) ** 2) / (2 * rms**2)) / (
             np.sqrt(2 * np.pi) * rms
         )
@@ -375,6 +386,8 @@ class CurvatureDistribution(WorkflowImplementation):
         minval = mean_curv - wfac * rms_curv
         maxval = mean_curv + wfac * rms_curv
         x_gauss = np.linspace(minval, maxval, 1001)
+        # TODO: divide-by-zero when rms_curv == 0 produces inf/nan in the
+        # Gaussian fit; guard rms_curv before dividing.
         y_gauss = np.exp(-((x_gauss - mean_curv) ** 2) / (2 * rms_curv**2)) / (
             np.sqrt(2 * np.pi) * rms_curv
         )
@@ -666,7 +679,7 @@ def scale_dependent_roughness_parameter(
 
     if topography.dim == 2:
         y_kwargs = dict(
-            func=lambda x, y=None: np.mean(x * x),
+            func=lambda x, y: np.mean(y * y),
             n=order_of_derivative,
             progress_callback=progress_callback,
             **kwargs,
@@ -719,6 +732,8 @@ def scale_dependent_roughness_parameter_for_surface(
     alerts = []
 
     # Factor of two for curvature
+    # TODO: set_progress(i + 1, n) can report progress > 100% (e.g. on the
+    # final step where i + 1 can exceed n); clamp the reported value to n.
     progress_callback = (
         None
         if progress_recorder is None
@@ -1232,6 +1247,8 @@ def _workflow_for_surface(
     series = []
     alerts = []
 
+    # TODO: set_progress(i + 1, n) can report progress > 100% (e.g. on the
+    # final step where i + 1 can exceed n); clamp the reported value to n.
     progress_callback = (
         None
         if progress_recorder is None


### PR DESCRIPTION
## Summary

Correctness fixes from a codebase audit of the statistics plugin.

- **y-direction scale-dependent roughness was wrong** — `scale_dependent_roughness_parameter` computed the y series from the x-derivative (`y_kwargs` used `np.mean(x * x)`, byte-identical to `x_kwargs`), so "Slope in y-direction" / "Curvature in y-direction" duplicated the x-direction curve. Since `scale_dependent_statistical_property` calls `func(dx, dy)`, the y-direction now uses `np.mean(y * y)`.
- **The test that should have caught it was vacuous** — `test_scale_dependent_slope_simple_2d_topography` filtered on a series name (`"Along y"`) that `ScaleDependentSlope` never emits, so its assertion never ran. It now asserts the y-direction slope ≈ 2 and x-direction ≈ 0 for `h(x,y) = -2y + 9` (verified to fail without the fix above).
- **Slope histogram ignored masks** — `_moments_histogram_gaussian` now `np.ma.compressed`es before histogramming, matching `HeightDistribution` / `CurvatureDistribution`, so masked fill values no longer corrupt the bins.

Gaussian `rms=0` divides, `>100%` progress, and the reentrant-message reuse are marked `TODO`.

> Note: this branch is **stacked on `fix/workflow-subject-url`** (open PR #65), so it targets that branch as its base. Merge/rebase after #65.

## Testing

`devbox run test-statistics`: 30 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
